### PR TITLE
fix: get viewport size tag via Cypress.config or add it via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ cy.vrtTrack("Whole page with default params");
 cy.get("#navbar").vrtTrack("Separate element with default params");
 
 cy.vrtTrack("Whole page with additional options", {
+  viewport: "1920x1080",
   os: "MacOS",
   device: "Cloud agent",
   diffTollerancePercent: 1,
@@ -133,7 +134,7 @@ cy.vrtTrack("Whole page with additional options", {
 });
 ```
 
-Viewport is taken from `Cypress.config()`
+Viewport is taken from `Cypress.config()`, if option is not set
 
 Browser is taken from `Cypress.browser.name`
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -37,6 +37,7 @@ declare namespace Cypress {
   }
 
   interface TrackOptions {
+    viewport?: string;
     os?: string;
     device?: string;
     diffTollerancePercent?: number;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -38,6 +38,7 @@ export function addVisualRegressionTrackerPlugin(on, config) {
         name,
         imageBase64,
         browser,
+        viewport,
         pixelRatio,
         os,
         device,
@@ -53,9 +54,7 @@ export function addVisualRegressionTrackerPlugin(on, config) {
         name,
         imageBase64,
         browser,
-        viewport: `${config.viewportWidth * pixelRatio}x${
-          config.viewportHeight * pixelRatio
-        }`,
+        viewport: viewport,
         os,
         device,
         diffTollerancePercent,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -61,7 +61,7 @@ export const trackImage = (
           name,
           imageBase64,
           browser: Cypress.browser.name,
-          viewport: options?.viewport ? options.viewport : Cypress.config("viewportWidth") * pixelRatio + "x" + Cypress.config("viewportHeight") * pixelRatio,
+          viewport: options?.viewport ?? `${Cypress.config("viewportWidth") * pixelRatio}x${Cypress.config("viewportHeight") * pixelRatio}`,
           pixelRatio,
           os: options?.os,
           device: options?.device,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -61,6 +61,7 @@ export const trackImage = (
           name,
           imageBase64,
           browser: Cypress.browser.name,
+          viewport: options?.viewport ? options.viewport : Cypress.config("viewportWidth") * pixelRatio + "x" + Cypress.config("viewportHeight") * pixelRatio,
           pixelRatio,
           os: options?.os,
           device: options?.device,


### PR DESCRIPTION
As I the current setup (Viewport tag is based on the config) is not really usable, I added the possibility to just add it in as an option or use Cypress.config as a default.

As I am not super firm with .ts and cypress codebase, this should be doublechecked.

closes #44 