### PR TITLE
feat: Add track without screenshot via buffer/base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ import {
   addVrtTrackCommand,
   addVrtStartCommand,
   addVrtStopCommand,
+  addVrtTrackBufferCommand,
+  addVrtTrackBase64Command,
 } from "@visual-regression-tracker/agent-cypress/dist/commands";
 
 addVrtStartCommand();
 addVrtStopCommand();
 addVrtTrackCommand();
+addVrtTrackBufferCommand();
+addVrtTrackBase64Command();
 ```
 
 ### Add plugin

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -6,6 +6,8 @@ import {
   trackImage,
   trackWithRetry,
   handleError,
+  trackBase64,
+  trackBuffer,
 } from "./utils";
 
 export const addVrtStartCommand = () => {
@@ -48,6 +50,32 @@ export const addVrtTrackCommand = () =>
         (result) => shouldStopRetry(result),
         (result) => checkResult(result),
         options?.retryLimit
+      );
+    }
+  );
+
+export const addVrtTrackBufferCommand = () =>
+  Cypress.Commands.add(
+    "vrtTrackBuffer",
+    {
+      prevSubject: false,
+    },
+    (name, imageBuffer, options) => {
+      trackBuffer(name, imageBuffer, options).then((result) =>
+        checkResult(result)
+      );
+    }
+  );
+
+export const addVrtTrackBase64Command = () =>
+  Cypress.Commands.add(
+    "vrtTrackBase64",
+    {
+      prevSubject: false,
+    },
+    (name, imageBase64, options) => {
+      trackBase64(name, imageBase64, options).then((result) =>
+        checkResult(result)
       );
     }
   );

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,6 +24,22 @@ declare namespace Cypress {
       >
     ): Chainable<null>;
 
+    vrtTrackBuffer(
+      name: string,
+      imageBuffer: Buffer,
+      options?: Partial<
+        Loggable & Timeoutable & ScreenshotOptions & TrackOptions
+      >
+    ): Chainable<null>;
+
+    vrtTrackBase64(
+      name: string,
+      imageBase64: string,
+      options?: Partial<
+        Loggable & Timeoutable & ScreenshotOptions & TrackOptions
+      >
+    ): Chainable<null>;
+
     vrtStart(): null;
 
     vrtStop(): null;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,5 +1,9 @@
 import { unlinkSync } from "fs";
-import { VisualRegressionTracker } from "@visual-regression-tracker/sdk-js";
+import {
+  VisualRegressionTracker,
+  multipartDtoToFormData,
+  bufferDtoToFormData,
+} from "@visual-regression-tracker/sdk-js";
 
 export function addVisualRegressionTrackerPlugin(on, config) {
   const vrtConfig = config?.env?.visualRegressionTracker;
@@ -27,29 +31,31 @@ export function addVisualRegressionTrackerPlugin(on, config) {
       return null;
     },
     ["VRT_TRACK_IMAGE_MULTIPART"]: async (props) => {
-      const {
-        name,
-        imagePath,
-        browser,
-        viewport,
-        os,
-        device,
-        diffTollerancePercent,
-        ignoreAreas,
-      } = props;
-
-      const result = await vrt["submitTestRunMultipart"]({
-        name,
-        imagePath,
-        browser,
-        viewport,
-        os,
-        device,
-        diffTollerancePercent,
-        ignoreAreas,
+      const data = multipartDtoToFormData({
+        ...props,
+        buildId: vrt.buildId,
+        projectId: vrt.projectId,
+        branchName: vrt.config.branchName,
       });
 
-      unlinkSync(imagePath);
+      const result = await vrt["submitTestRunMultipart"](data);
+
+      unlinkSync(props.imagePath);
+      return result;
+    },
+    ["VRT_TRACK_BUFFER_MULTIPART"]: async (props) => {
+      const data = bufferDtoToFormData({
+        ...props,
+        buildId: vrt.buildId,
+        projectId: vrt.projectId,
+        branchName: vrt.config.branchName,
+      });
+
+      const result = await vrt["submitTestRunMultipart"](data);
+      return result;
+    },
+    ["VRT_TRACK_IMAGE_BASE64"]: async (props) => {
+      const result = await vrt["submitTestRunBase64"](props);
       return result;
     },
     ["VRT_PROCESS_ERROR_RESULT"]: async (testRunResult) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,11 @@
 /* global Cypress, cy */
 
-import { TestRunResponse, TestStatus } from "@visual-regression-tracker/sdk-js";
+import {
+  bufferDtoToFormData,
+  multipartDtoToFormData,
+  TestRunResponse,
+  TestStatus,
+} from "@visual-regression-tracker/sdk-js";
 
 export const log = (message: string) =>
   Cypress.log({
@@ -17,11 +22,11 @@ export const handleError = (err: unknown) => {
 
 export const toTestRunDto = ({
   name,
-  pixelRatio,
+  pixelRatio = 1,
   options,
 }: {
   name: string;
-  pixelRatio: number;
+  pixelRatio?: number;
   options: any;
 }) => ({
   name,
@@ -89,4 +94,36 @@ export const trackImage = (
         { log: false }
       )
     );
+};
+
+export const trackBuffer = (
+  name: string,
+  imageBuffer: Buffer,
+  options: any
+): Cypress.Chainable<TestRunResponse> => {
+  log(`tracking ${name}`);
+  return cy.task(
+    "VRT_TRACK_BUFFER_MULTIPART",
+    {
+      ...toTestRunDto({ name, options }),
+      imageBuffer,
+    },
+    { log: false }
+  );
+};
+
+export const trackBase64 = (
+  name: string,
+  imageBase64: string,
+  options: any
+): Cypress.Chainable<TestRunResponse> => {
+  log(`tracking ${name}`);
+  return cy.task(
+    "VRT_TRACK_IMAGE_BASE64",
+    {
+      ...toTestRunDto({ name, options }),
+      imageBase64,
+    },
+    { log: false }
+  );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -854,9 +854,9 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.7.0.tgz",
-      "integrity": "sha512-diY0qMPyQjfu4rDu3kDhJ9qIZadIm4IISO3RJSv9ajYUWJUCO0AykbgzLcg1xclxtXgzY583u3gAv66M6zz5SA==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.4.tgz",
+      "integrity": "sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.6.0",
@@ -1220,9 +1220,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.7.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.7.tgz",
-      "integrity": "sha512-bxWC4rgIF/FjM7JsPvpk6ZKGITgw27qsYCbi6h4kWZWYpchOLENgvFaRBZUc64Q/M1y+X2EteahRbyo8QFCKdw==",
+      "version": "16.7.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.8.tgz",
+      "integrity": "sha512-8upnoQU0OPzbIkm+ZMM0zCeFCkw2s3mS0IWdx0+AAaWqm4fkBb0UJp8Edl7FVKRamYbpJC/aVsHpKWBIbiC7Zg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1293,9 +1293,9 @@
       }
     },
     "@visual-regression-tracker/sdk-js": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@visual-regression-tracker/sdk-js/-/sdk-js-5.0.0.tgz",
-      "integrity": "sha512-2LvZQxAl1Koi0/Wch7VZc0pw/bOkKrs1mny9j6dYbjujnFI1l2FGmTDgavPfgCZrvEjaE+tQpITgfp894oQ26g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@visual-regression-tracker/sdk-js/-/sdk-js-5.1.1.tgz",
+      "integrity": "sha512-QGnG5Og6+9x6ruMx4jg5QIX+OoJ9nzCdpaszFtWwwuowOifTxHOxSuXF73syUDg1m2Unslf/deVdKFz1wVIPrw==",
       "requires": {
         "axios": "^0.21.0",
         "form-data": "^4.0.0"
@@ -2239,12 +2239,12 @@
       }
     },
     "cypress": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.7.0.tgz",
-      "integrity": "sha512-uYBYXNoI5ym0UxROwhQXWTi8JbUEjpC6l/bzoGZNxoKGsLrC1SDPgIDJMgLX/MeEdPL0UInXLDUWN/rSyZUCjQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.3.1.tgz",
+      "integrity": "sha512-1v6pfx+/5cXhaT5T6QKOvnkawmEHWHLiVzm3MYMoQN1fkX2Ma1C32STd3jBStE9qT5qPSTILjGzypVRxCBi40g==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.5",
+        "@cypress/request": "^2.88.6",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "^6.0.2",
@@ -6193,8 +6193,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "npm-package-arg": "^8.1.1",
+            "pacote": "^11.3.0",
             "tar": "^6.1.0"
           }
         },
@@ -9564,9 +9564,9 @@
       }
     },
     "ws": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
-      "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   },
   "homepage": "https://github.com/Visual-Regression-Tracker/agent-cypress#readme",
   "dependencies": {
-    "@visual-regression-tracker/sdk-js": "5.0.0"
+    "@visual-regression-tracker/sdk-js": "5.1.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",
     "@types/node": "^16.7.7",
-    "cypress": "^7.7.0",
+    "cypress": "^8.3.1",
     "jest": "^26.6.3",
     "semantic-release": "^17.4.7",
     "ts-jest": "^26.5.6",


### PR DESCRIPTION
bump `@visual-regression-tracker/sdk-js` to 5.1.1
bump `cypress` to 8.3.1