### PR TITLE
feat: Add keepScreenshot option (usefull for reports)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ cy.vrtTrack("Whole page with additional options", {
   device: "Cloud agent",
   customTags: "Cloud, DarkTheme, Auth",
   diffTollerancePercent: 1,
+  keepScreenshot: false, // Keep screenshot copy on the user's disk
   ignoreAreas: [{ x: 1, y: 2, width: 100, height: 200 }],
   retryLimit: 2,
 });

--- a/cypress/integration/example.spec.js
+++ b/cypress/integration/example.spec.js
@@ -34,6 +34,7 @@ context("Visual Regression Tracker", () => {
       device: "Cloud agent",
       customTags: "Cloud, DarkTheme, Auth",
       diffTollerancePercent: 0,
+      keepScreenshot: true,
       ignoreAreas: [
         {
           x: 0,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,6 +12,7 @@ declare namespace Cypress {
      *       device: "Cloud agent",
      *       customTags: "Cloud, DarkTheme, Auth",
      *       diffTollerancePercent: 1.23,
+     *       keepScreenshot: false,
      *       ignoreAreas: [
      *         {x: 1, y: 2, width: 100, height: 200}
      *       ],
@@ -59,6 +60,7 @@ declare namespace Cypress {
     device?: string;
     customTags?: string;
     diffTollerancePercent?: number;
+    keepScreenshot?: boolean;
     ignoreAreas?: IgnoreArea[];
     retryLimit?: number;
   }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -40,7 +40,8 @@ export function addVisualRegressionTrackerPlugin(on, config) {
 
       const result = await vrt["submitTestRunMultipart"](data);
 
-      unlinkSync(props.imagePath);
+      if (props.keepScreenshot !== true) { unlinkSync(props.imagePath); }
+  
       return result;
     },
     ["VRT_TRACK_BUFFER_MULTIPART"]: async (props) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -40,6 +40,7 @@ export const toTestRunDto = ({
   device: options?.device,
   customTags: options?.customTags,
   diffTollerancePercent: options?.diffTollerancePercent,
+  keepScreenshot: options?.keepScreenshot,
   ignoreAreas: options?.ignoreAreas,
 });
 


### PR DESCRIPTION
Cypress agent currently auto-delete all taked (with vrtTake()) screenshots. This PR make this behavior optional.
Usefull to fix error with reporters, like Mochawesome for Cypress:
![image](https://user-images.githubusercontent.com/33355363/133620654-e61f0e3b-a07e-4ea0-bc92-fdd339acfaa8.png)
