### PR TITLE
feat: add optional keepScreenshot option to vrtTrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ cy.vrtTrack("Whole page with additional options", {
   diffTollerancePercent: 1,
   ignoreAreas: [{ x: 1, y: 2, width: 100, height: 200 }],
   retryLimit: 2,
+  keepScreenshot: false, // Keep screenshot local copy, false by default
 });
 ```
 

--- a/cypress/integration/example.spec.js
+++ b/cypress/integration/example.spec.js
@@ -34,6 +34,7 @@ context("Visual Regression Tracker", () => {
       device: "Cloud agent",
       customTags: "Cloud, DarkTheme, Auth",
       diffTollerancePercent: 0,
+      keepScreenshot: true,
       ignoreAreas: [
         {
           x: 0,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,13 +15,17 @@ declare namespace Cypress {
      *       ignoreAreas: [
      *         {x: 1, y: 2, width: 100, height: 200}
      *       ],
-     *       retryLimit: 5
+     *       retryLimit: 5,
+     *       keepScreenshot: false,
      *    })
      */
     vrtTrack(
       name: string,
       options?: Partial<
-        Loggable & Timeoutable & ScreenshotOptions & TrackOptions
+        Loggable &
+          Timeoutable &
+          ScreenshotOptions &
+          TrackOptions & { keepScreenshot?: boolean }
       >
     ): Chainable<null>;
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -40,7 +40,9 @@ export function addVisualRegressionTrackerPlugin(on, config) {
 
       const result = await vrt["submitTestRunMultipart"](data);
 
-      unlinkSync(props.imagePath);
+      if (!props.keepScreenshot) {
+        unlinkSync(props.imagePath);
+      }
       return result;
     },
     ["VRT_TRACK_BUFFER_MULTIPART"]: async (props) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -41,6 +41,7 @@ export const toTestRunDto = ({
   customTags: options?.customTags,
   diffTollerancePercent: options?.diffTollerancePercent,
   ignoreAreas: options?.ignoreAreas,
+  keepScreenshot: options?.keepScreenshot,
 });
 
 export const trackWithRetry = (


### PR DESCRIPTION
There is already a [PR](https://github.com/Visual-Regression-Tracker/agent-cypress/pull/159) out for this change, but the requested changes were not addressed, it's been months. 

I am creating this PR so we can have this option in the cypress agent, especially since I have a use case for it. 