### PR TITLE
Use cypress run events to automatically signal the test run to VRT

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,6 +8,13 @@ import {
 export function addVisualRegressionTrackerPlugin(on, config) {
   const vrtConfig = config?.env?.visualRegressionTracker;
   let vrt = new VisualRegressionTracker(vrtConfig);
+  
+  on("before:run", async () => {
+    await vrt.start();
+  }
+  on("after:run", async () => {
+    await vrt.stop();
+  }
 
   on("task", {
     ["VRT_START"]: async (props) => {


### PR DESCRIPTION
In my opinion it would make sense if the plugin automatically starts and stops when the cypress run starts and stops.

My suggestion would be to use the cypress events to do it. Makes the usage much simpler and also prevents the VRT plugin turn on / off the progress indicator for every spec. 

Whats your opinion on this?