### PR TITLE
Use the same Node.js version minimum as Cypress is using

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@visual-regression-tracker/agent-cypress",
   "version": "5.6.0",
-  "description": "Visual Regression Tracker integration plugin",
+  "description": "Visual Regression Tracker integration plugin for Cypress",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -23,6 +23,9 @@
     "url": "https://github.com/Visual-Regression-Tracker/agent-cypress/issues"
   },
   "homepage": "https://github.com/Visual-Regression-Tracker/agent-cypress#readme",
+  "engines": {
+    "node": ">=16.16.0"
+  },
   "dependencies": {
     "@visual-regression-tracker/sdk-js": "5.6.0"
   },


### PR DESCRIPTION
https://github.com/cypress-io/cypress/blob/develop/package.json#L212

This helps guiding on what are the supported Node.js versions.